### PR TITLE
Check ARSession state during startup

### DIFF
--- a/Assets/Scripts/ARCoreSupportChecker.cs
+++ b/Assets/Scripts/ARCoreSupportChecker.cs
@@ -8,19 +8,18 @@ public class ARCoreSupportChecker : MonoBehaviour
     [Header("UI References")]
     public TMP_Text warningText;
 
-    async void Start()
+    IEnumerator Start()
     {
-        SessionAvailability availability = await ARSession.CheckAvailability();
+        // Check AR support on the current device
+        yield return ARSession.CheckAvailability();
 
-        if (availability == SessionAvailability.Supported)
+        if (ARSession.state == ARSessionState.NeedsInstall)
         {
-            return; // ARCore is ready
+            // Request AR package installation
+            yield return ARSession.Install();
         }
-        else if (availability == SessionAvailability.NeedsInstall)
-        {
-            await ARSession.Install();
-        }
-        else if (availability == SessionAvailability.Unsupported)
+
+        if (ARSession.state == ARSessionState.Unsupported)
         {
             if (warningText != null)
             {

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@
 
 ### Verificar soporte ARCore
 
-La escena `Index.unity` incluye el script `ARCoreSupportChecker` que comprueba la disponibilidad de ARCore al iniciar la aplicación.
+La escena `Index.unity` incluye el script `ARCoreSupportChecker` que comprueba la disponibilidad de ARCore al iniciar la aplicación. Tras cada llamada a `ARSession.CheckAvailability()` y `ARSession.Install()`, el script revisa `ARSession.state`.
 
-- **Supported** → la app continúa normalmente.
+- **Ready** → la app continúa normalmente.
 - **NeedsInstall** → se solicita instalar ARCore.
 - **Unsupported** → se muestra un mensaje en pantalla indicando que el dispositivo no es compatible.
 


### PR DESCRIPTION
## Summary
- wait for AR session setup using coroutine
- show unsupported warning if `ARSession.state` reports it
- mention `ARSession.state` check in the README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684e01987e98832299c1a07ca3d3bb3b