### PR TITLE
Implement brain-tumor fusion

### DIFF
--- a/Assets/Scripts/MedicalMeshLoader.cs
+++ b/Assets/Scripts/MedicalMeshLoader.cs
@@ -21,6 +21,34 @@ public class MedicalMeshLoader : MonoBehaviour
     public Material brainMaterial;   // blanco semitransparente
     public Material tumorMaterial;   // rojo sólido
 
+    [Header("Objeto raíz para la fusión")]
+    public string parentObjectName = "BrainTumorCombined";
+
+    void Awake()
+    {
+        // Si no se asignaron materiales desde el inspector, crea unos por defecto
+        if (brainMaterial == null)
+        {
+            brainMaterial = new Material(Shader.Find("Standard"));
+            var c = Color.white;
+            c.a = 0.3f;                    // Semitransparente
+            brainMaterial.color = c;
+            brainMaterial.SetFloat("_Mode", 3);
+            brainMaterial.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.SrcAlpha);
+            brainMaterial.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
+            brainMaterial.SetInt("_ZWrite", 0);
+            brainMaterial.DisableKeyword("_ALPHATEST_ON");
+            brainMaterial.EnableKeyword("_ALPHABLEND_ON");
+            brainMaterial.DisableKeyword("_ALPHAPREMULTIPLY_ON");
+            brainMaterial.renderQueue = 3000;
+        }
+        if (tumorMaterial == null)
+        {
+            tumorMaterial = new Material(Shader.Find("Standard"));
+            tumorMaterial.color = Color.red;
+        }
+    }
+
     /// <summary>
     /// Invocado desde FileSelector para cargar el cerebro
     /// </summary>
@@ -139,6 +167,17 @@ public class MedicalMeshLoader : MonoBehaviour
         go.transform.position   = Vector3.zero;
         go.transform.rotation   = Quaternion.Euler(-90, 0, 0);
         go.transform.localScale = Vector3.one;
+
+        // Asegura objeto raíz para agrupar cerebro y tumor
+        var parent = GameObject.Find(parentObjectName);
+        if (parent == null)
+        {
+            parent = new GameObject(parentObjectName);
+            parent.transform.position = Vector3.zero;
+            parent.transform.rotation = Quaternion.identity;
+            parent.transform.localScale = Vector3.one;
+        }
+        go.transform.SetParent(parent.transform, false);
 
         Debug.Log($"✅ {goName} cargado y añadido a la escena.");
     }

--- a/README.md
+++ b/README.md
@@ -90,3 +90,13 @@ main   ←  estable, solo demos/versiones
 - **feature/\***: rama por Historia de Usuario o tarea (< 3-4 días).
 - **hotfix/\***: correcciones urgentes desde _main_ (se cherry-pickean a _dev_).
 - Para pasar a main solo sera a traves de PR.
+
+---
+
+## 6 · Fusión de cerebro y tumor
+
+El script **MedicalMeshLoader** ahora agrupa el cerebro y el tumor en un
+objeto raíz llamado `BrainTumorCombined`. Al cargar ambos modelos se
+aplican materiales por defecto: el cerebro se muestra en blanco
+semitransparente y el tumor en rojo sólido. Esto permite apreciar la
+relación espacial de forma inmediata y moverlos como una única entidad.


### PR DESCRIPTION
## Summary
- add default transparent brain and red tumor materials
- create parent object `BrainTumorCombined` for brain and tumor
- document fused loading of brain and tumor

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68524aba2dc483228114d2cf163347a5