### PR TITLE
Add fused mesh export option

### DIFF
--- a/Assets/Scripts/MedicalMeshLoader.cs
+++ b/Assets/Scripts/MedicalMeshLoader.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using System.IO;
 using System.Diagnostics;      // Para ProcessStartInfo, Process
 using System.Collections;
+using System.Text;
 #if UNITY_EDITOR
 using UnityEditor;             // AssetDatabase
 #endif
@@ -16,6 +17,13 @@ public class MedicalMeshLoader : MonoBehaviour
     [Header("Paths de salida OBJ dentro de Assets/Models/")]
     public string brainObjPath = "Assets/Models/brain_model.obj";
     public string tumorObjPath = "Assets/Models/tumor_model.obj";
+    [Header("Salida modelo fusionado")]
+    public string fusedObjPath = "Assets/Models/fused_model.obj";
+    public bool showModelsInScene = false;
+
+    private Mesh brainMesh;
+    private Mesh tumorMesh;
+
 
     [Header("Materiales")]
     public Material brainMaterial;   // blanco semitransparente
@@ -124,6 +132,12 @@ public class MedicalMeshLoader : MonoBehaviour
             Debug.LogError("❌ No se pudo cargar el mesh: " + relativePath);
             yield break;
         }
+        if (goName == "BrainModel") brainMesh = mesh;
+        else if (goName == "TumorModel") tumorMesh = mesh;
+        if (!showModelsInScene) {
+            TrySaveMergedMesh();
+            yield break;
+        }
 
         // Si ya existía, lo destruye
         var oldGO = GameObject.Find(goName);
@@ -162,9 +176,8 @@ public class MedicalMeshLoader : MonoBehaviour
         go.transform.rotation   = Quaternion.Euler(-90, 0, 0);
         go.transform.localScale = Vector3.one;
 
-        TryMergeModels();
-
-        Debug.Log($"✅ {goName} cargado y añadido a la escena.");
+        if (showModelsInScene)
+            TryMergeModels();
     }
 
     void TryMergeModels()
@@ -176,6 +189,43 @@ public class MedicalMeshLoader : MonoBehaviour
             tumor.transform.SetParent(brain.transform, true);
         }
     }
+    void TrySaveMergedMesh()
+    {
+        if (brainMesh != null && tumorMesh != null)
+        {
+            var combine = new CombineInstance[2];
+            combine[0].mesh = brainMesh;
+            combine[0].transform = Matrix4x4.identity;
+            combine[1].mesh = tumorMesh;
+            combine[1].transform = Matrix4x4.identity;
+            var merged = new Mesh();
+            merged.CombineMeshes(combine, true, false);
+            string full = Path.GetFullPath(fusedObjPath).Replace("\\","/");
+            File.WriteAllText(full, MeshToObj(merged));
+#if UNITY_EDITOR
+            AssetDatabase.Refresh();
+#endif
+            Debug.Log($"✅ Modelos fusionados guardados en {fusedObjPath}");
+        }
+    }
+
+    string MeshToObj(Mesh m)
+    {
+        var sb = new StringBuilder();
+        foreach (var v in m.vertices) sb.AppendLine($"v {v.x} {v.y} {v.z}");
+        foreach (var n in m.normals) sb.AppendLine($"vn {n.x} {n.y} {n.z}");
+        foreach (var uv in m.uv) sb.AppendLine($"vt {uv.x} {uv.y}");
+        int[] tris = m.triangles;
+        for (int i = 0; i < tris.Length; i += 3)
+        {
+            int a = tris[i] + 1;
+            int b = tris[i+1] + 1;
+            int c = tris[i+2] + 1;
+            sb.AppendLine($"f {a}/{a}/{a} {b}/{b}/{b} {c}/{c}/{c}");
+        }
+        return sb.ToString();
+    }
+
 }
 
 


### PR DESCRIPTION
## Summary
- load brain/tumor OBJ files without instantiating meshes
- export a merged brain+tumor OBJ
- hide models in scene when `showModelsInScene` is disabled

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6852538c49188322a5b4f6912e4095bd